### PR TITLE
Add mixer CLI and setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Byte-compiled / cache
+__pycache__/
+*.py[cod]
+*.so
+
+# Virtualenv
+.venv/
+venv/
+ENV/
+
+# Logs / output
+*.log
+output/
+
+# Audio files
+*.wav
+*.mp3
+*.flac
+*.ogg
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Packaging
+build/
+dist/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# carwash
+# Car Wash Mixer
+
+A minimal CLI for audio cleanup and lyric mapping.
+
+## Setup
+
+```bash
+./setup.sh
+```
+
+Or manually:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+Clean an audio track:
+
+```bash
+wash-mix mix --input song.wav --output cleaned.wav
+```
+
+Create a lyrics mapping (from an LRC file):
+
+```bash
+wash-mix map-lyrics --lyrics song.lrc --bpm 120 --output mapping.json
+```
+
+The mapping JSON keys combine bar numbers and timestamps for easy reference.

--- a/mixer.py
+++ b/mixer.py
@@ -1,0 +1,72 @@
+import json
+import re
+from pathlib import Path
+
+import click
+from pydub import AudioSegment
+import pyloudnorm as pyln
+
+
+@click.group()
+def cli():
+    """Car Wash Mixer CLI."""
+    pass
+
+
+@cli.command()
+@click.option("--input", "infile", required=True, type=click.Path(exists=True), help="Input audio file")
+@click.option("--output", "outfile", required=True, type=click.Path(), help="Output cleaned file")
+@click.option("--preset", default="car-wash", help="Mix preset (unused)")
+def mix(infile: str, outfile: str, preset: str):
+    """Normalize loudness to -14 LUFS and export."""
+    audio = AudioSegment.from_file(infile)
+    meter = pyln.Meter(audio.frame_rate)
+    samples = audio.get_array_of_samples()
+    loudness = meter.integrated_loudness(samples)
+    normalized = pyln.normalize.loudness(samples, loudness, -14.0)
+    cleaned = AudioSegment(
+        data=normalized.tobytes(),
+        sample_width=audio.sample_width,
+        frame_rate=audio.frame_rate,
+        channels=audio.channels,
+    )
+    cleaned.export(outfile, format=Path(outfile).suffix.lstrip("."))
+    click.echo(f"Done. Loudness was {loudness:.2f} LUFS, now -14 LUFS.")
+
+
+@cli.command()
+@click.option("--lyrics", "lyrics_path", required=True, type=click.Path(exists=True), help="Input LRC file")
+@click.option("--bpm", type=float, required=True, help="Beats per minute")
+@click.option("--beats-per-bar", default=4, type=int, show_default=True, help="Beats per bar")
+@click.option("--offset", default=0.0, type=float, show_default=True, help="Seconds offset before first beat")
+@click.option("--output", "output_json", required=True, type=click.Path(), help="Output JSON file")
+def map_lyrics(lyrics_path: str, bpm: float, beats_per_bar: int, offset: float, output_json: str):
+    """Convert LRC lyrics to a JSON mapping keyed by bar and timestamp."""
+    beat_duration = 60.0 / bpm
+    bar_duration = beat_duration * beats_per_bar
+    mapping = {}
+
+    timestamp_pattern = re.compile(r"\[(\d+):(\d+(?:\.\d+)?)\]")
+    with open(lyrics_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            match = timestamp_pattern.match(line)
+            if not match:
+                continue
+            minutes = int(match.group(1))
+            seconds = float(match.group(2))
+            text = line[match.end():].strip()
+            ts = minutes * 60 + seconds
+            bar_index = int((ts - offset) / bar_duration) + 1
+            key = f"bar_{bar_index}_{ts:.2f}"
+            mapping[key] = text
+
+    with open(output_json, "w", encoding="utf-8") as f:
+        json.dump(mapping, f, indent=2)
+    click.echo(f"Wrote {len(mapping)} mappings to {output_json}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+click
+pydub
+librosa
+pyloudnorm
+openai

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup
+
+setup(
+    name="carwash",
+    version="0.1.0",
+    py_modules=["mixer"],
+    install_requires=[
+        "Flask",
+        "click",
+        "pydub",
+        "librosa",
+        "pyloudnorm",
+        "openai",
+    ],
+    entry_points={
+        "console_scripts": [
+            "wash-mix = mixer:cli",
+        ],
+    },
+)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+if command -v apt >/dev/null 2>&1; then
+  sudo apt update
+  sudo apt install -y ffmpeg libsndfile1
+elif command -v brew >/dev/null 2>&1; then
+  brew install ffmpeg libsndfile
+else
+  echo "Install ffmpeg and libsndfile manually" >&2
+fi
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Done. Activate with: source .venv/bin/activate"


### PR DESCRIPTION
## Summary
- implement CLI `wash-mix` with `mix` and `map-lyrics` commands
- add setup script, packaging, and ignore rules
- expand README with install and usage instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686fbcddfb14833198f91060206b5a92