### PR TITLE
Add API server and plugin schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,16 @@ wash-mix map-lyrics --lyrics song.lrc --bpm 120 --output mapping.json
 ```
 
 The mapping JSON keys combine bar numbers and timestamps for easy reference.
+
+## API and Custom GPT
+
+You can run a small Flask server exposing these features as a ChatGPT
+plugin:
+
+```bash
+python server.py
+```
+
+The `ai-plugin.json` and `openapi.json` files describe the available
+endpoints so you can create a custom GPT that calls the `/mix` and
+`/map-lyrics` routes directly.

--- a/ai-plugin.json
+++ b/ai-plugin.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "Car Wash Mixer",
+  "name_for_model": "carwash",
+  "description_for_human": "Normalize audio and create lyric mappings.",
+  "description_for_model": "Plugin for audio normalization and lyric mapping using local file paths.",
+  "auth": {"type": "none"},
+  "api": {
+    "type": "openapi",
+    "url": "http://localhost:5000/openapi.json"
+  },
+  "logo_url": "https://example.com/logo.png",
+  "contact_email": "support@example.com",
+  "legal_info_url": "https://example.com/legal"
+}

--- a/mixer.py
+++ b/mixer.py
@@ -13,12 +13,11 @@ def cli():
     pass
 
 
-@cli.command()
-@click.option("--input", "infile", required=True, type=click.Path(exists=True), help="Input audio file")
-@click.option("--output", "outfile", required=True, type=click.Path(), help="Output cleaned file")
-@click.option("--preset", default="car-wash", help="Mix preset (unused)")
-def mix(infile: str, outfile: str, preset: str):
-    """Normalize loudness to -14 LUFS and export."""
+def mix_audio(infile: str, outfile: str, preset: str = "car-wash") -> float:
+    """Normalize loudness to -14 LUFS and export.
+
+    Returns the original loudness of the file.
+    """
     audio = AudioSegment.from_file(infile)
     meter = pyln.Meter(audio.frame_rate)
     samples = audio.get_array_of_samples()
@@ -31,20 +30,30 @@ def mix(infile: str, outfile: str, preset: str):
         channels=audio.channels,
     )
     cleaned.export(outfile, format=Path(outfile).suffix.lstrip("."))
-    click.echo(f"Done. Loudness was {loudness:.2f} LUFS, now -14 LUFS.")
+    return loudness
 
 
 @cli.command()
-@click.option("--lyrics", "lyrics_path", required=True, type=click.Path(exists=True), help="Input LRC file")
-@click.option("--bpm", type=float, required=True, help="Beats per minute")
-@click.option("--beats-per-bar", default=4, type=int, show_default=True, help="Beats per bar")
-@click.option("--offset", default=0.0, type=float, show_default=True, help="Seconds offset before first beat")
-@click.option("--output", "output_json", required=True, type=click.Path(), help="Output JSON file")
-def map_lyrics(lyrics_path: str, bpm: float, beats_per_bar: int, offset: float, output_json: str):
-    """Convert LRC lyrics to a JSON mapping keyed by bar and timestamp."""
+@click.option("--input", "infile", required=True, type=click.Path(exists=True), help="Input audio file")
+@click.option("--output", "outfile", required=True, type=click.Path(), help="Output cleaned file")
+@click.option("--preset", default="car-wash", help="Mix preset (unused)")
+def mix(infile: str, outfile: str, preset: str):
+    """CLI wrapper for :func:`mix_audio`."""
+    loudness = mix_audio(infile, outfile, preset)
+    click.echo(f"Done. Loudness was {loudness:.2f} LUFS, now -14 LUFS.")
+
+
+def map_lyrics_file(
+    lyrics_path: str,
+    bpm: float,
+    beats_per_bar: int = 4,
+    offset: float = 0.0,
+    output_json: str | None = None,
+) -> dict:
+    """Convert LRC lyrics to a mapping keyed by bar and timestamp."""
     beat_duration = 60.0 / bpm
     bar_duration = beat_duration * beats_per_bar
-    mapping = {}
+    mapping: dict[str, str] = {}
 
     timestamp_pattern = re.compile(r"\[(\d+):(\d+(?:\.\d+)?)\]")
     with open(lyrics_path, "r", encoding="utf-8") as f:
@@ -63,8 +72,22 @@ def map_lyrics(lyrics_path: str, bpm: float, beats_per_bar: int, offset: float, 
             key = f"bar_{bar_index}_{ts:.2f}"
             mapping[key] = text
 
-    with open(output_json, "w", encoding="utf-8") as f:
-        json.dump(mapping, f, indent=2)
+    if output_json:
+        with open(output_json, "w", encoding="utf-8") as f:
+            json.dump(mapping, f, indent=2)
+
+    return mapping
+
+
+@cli.command()
+@click.option("--lyrics", "lyrics_path", required=True, type=click.Path(exists=True), help="Input LRC file")
+@click.option("--bpm", type=float, required=True, help="Beats per minute")
+@click.option("--beats-per-bar", default=4, type=int, show_default=True, help="Beats per bar")
+@click.option("--offset", default=0.0, type=float, show_default=True, help="Seconds offset before first beat")
+@click.option("--output", "output_json", required=True, type=click.Path(), help="Output JSON file")
+def map_lyrics(lyrics_path: str, bpm: float, beats_per_bar: int, offset: float, output_json: str):
+    """CLI wrapper for :func:`map_lyrics_file`."""
+    mapping = map_lyrics_file(lyrics_path, bpm, beats_per_bar, offset, output_json)
     click.echo(f"Wrote {len(mapping)} mappings to {output_json}")
 
 

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,62 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Car Wash Mixer API",
+    "version": "1.0.0",
+    "description": "API to normalize audio files and map lyrics."
+  },
+  "paths": {
+    "/mix": {
+      "post": {
+        "operationId": "mix",
+        "summary": "Normalize audio to -14 LUFS",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "input": {"type": "string", "description": "Path to input audio"},
+                  "output": {"type": "string", "description": "Output file path"},
+                  "preset": {"type": "string", "default": "car-wash"}
+                },
+                "required": ["input", "output"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {"description": "Mix completed"}
+        }
+      }
+    },
+    "/map-lyrics": {
+      "post": {
+        "operationId": "mapLyrics",
+        "summary": "Convert LRC lyrics to JSON mapping",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "lyrics": {"type": "string", "description": "Path to LRC file"},
+                  "bpm": {"type": "number"},
+                  "beats_per_bar": {"type": "integer", "default": 4},
+                  "offset": {"type": "number", "default": 0.0},
+                  "output": {"type": "string", "description": "Output JSON path"}
+                },
+                "required": ["lyrics", "bpm", "output"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {"description": "Mapping generated"}
+        }
+      }
+    }
+  }
+}

--- a/server.py
+++ b/server.py
@@ -1,0 +1,37 @@
+from flask import Flask, jsonify, request, send_file
+from pathlib import Path
+
+from mixer import mix_audio, map_lyrics_file
+
+app = Flask(__name__)
+
+
+@app.route("/mix", methods=["POST"])
+def mix_endpoint():
+    data = request.get_json(force=True)
+    infile = data["input"]
+    outfile = data["output"]
+    preset = data.get("preset", "car-wash")
+    loudness = mix_audio(infile, outfile, preset)
+    return jsonify({"message": f"Normalized to -14 LUFS", "original_loudness": loudness})
+
+
+@app.route("/map-lyrics", methods=["POST"])
+def map_lyrics_endpoint():
+    data = request.get_json(force=True)
+    lyrics = data["lyrics"]
+    bpm = float(data["bpm"])
+    beats_per_bar = int(data.get("beats_per_bar", 4))
+    offset = float(data.get("offset", 0.0))
+    output = data["output"]
+    mapping = map_lyrics_file(lyrics, bpm, beats_per_bar, offset, output)
+    return jsonify({"message": f"Wrote {len(mapping)} mappings", "count": len(mapping)})
+
+
+@app.route("/openapi.json")
+def openapi_spec():
+    return send_file(Path(__file__).with_name("openapi.json"))
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- expose mixing and lyric mapping as functions and CLI wrappers
- add a simple Flask API server
- document a small openapi spec and plugin manifest
- update README with instructions

## Testing
- `python3 -m py_compile mixer.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_686fcbf11c2c8331add7e1f220c7194d