### PR TITLE
Add plugin manifest endpoint and privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,3 @@
+# Privacy Policy
+
+We do not collect any personal data. Audio and lyric files are processed locally and not stored after processing.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ python server.py
 The `ai-plugin.json` and `openapi.json` files describe the available
 endpoints so you can create a custom GPT that calls the `/mix` and
 `/map-lyrics` routes directly.
+
+Import the plugin using the following manifest URL once the server is
+running:
+
+```
+http://localhost:5000/.well-known/ai-plugin.json
+```
+
+The privacy policy can be viewed at:
+
+```
+http://localhost:5000/privacy
+```

--- a/ai-plugin.json
+++ b/ai-plugin.json
@@ -11,5 +11,5 @@
   },
   "logo_url": "https://example.com/logo.png",
   "contact_email": "support@example.com",
-  "legal_info_url": "https://example.com/legal"
+  "legal_info_url": "http://localhost:5000/privacy"
 }

--- a/server.py
+++ b/server.py
@@ -33,5 +33,17 @@ def openapi_spec():
     return send_file(Path(__file__).with_name("openapi.json"))
 
 
+@app.route("/.well-known/ai-plugin.json")
+def plugin_manifest():
+    """Serve the plugin manifest for ChatGPT."""
+    return send_file(Path(__file__).with_name("ai-plugin.json"))
+
+
+@app.route("/privacy")
+def privacy_policy():
+    """Serve the privacy policy markdown file."""
+    return send_file(Path(__file__).with_name("PRIVACY.md"))
+
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- expose `/.well-known/ai-plugin.json` in server
- add `/privacy` endpoint and PRIVACY.md
- link privacy policy in `ai-plugin.json`
- document manifest and privacy URLs in README

## Testing
- `python -m py_compile server.py mixer.py`
- start server and `curl` the manifest and privacy URLs

------
https://chatgpt.com/codex/tasks/task_e_686fd4dbf7108331aef25e5e6c6ce2a3